### PR TITLE
feature/cppcheck documentation links

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as cp from 'child_process';
 import * as path from "path";
 import * as xml2js from 'xml2js';
 
+import { documentationLinkMap } from './util/documentation';
 import { runCommand } from './util/scripts';
 import { resolvePath, findWorkspaceRoot } from './util/path';
 
@@ -294,7 +295,11 @@ async function runCppcheckOnFileXML(
                 const range = new vscode.Range(line, col, line, document.lineAt(line).text.length);
                 const diagnostic = new vscode.Diagnostic(range, e.$.msg, severity);
                 diagnostic.source = "cppcheck";
-                diagnostic.code = e.$.id;
+                // If we have a link to documentation, include it
+                diagnostic.code = documentationLinkMap[e.$.id] ? {
+                    value: e.$.id,
+                    target: vscode.Uri.parse(documentationLinkMap[e.$.id])
+                } : e.$.id;
 
                 // Related Information
                 const relatedInfos: vscode.DiagnosticRelatedInformation[] = [];

--- a/src/util/documentation.ts
+++ b/src/util/documentation.ts
@@ -1,0 +1,16 @@
+const documentationLinkMap : Record<string, string> = {
+  'constParameterPointer': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/constParameterPointer.md',
+  'cstyleCast': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/cstyleCast.md',
+  'dangerousTypeCast': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/dangerousTypeCast.md',
+  'duplicateExpressionTernary': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/duplicateExpressionTernary.md',
+  'duplicateValueTernary': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/duplicateValueTernary.md',
+  'fcloseInLoopCondition': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/fcloseInLoopCondition.md',
+  'functionConst': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/functionConst.md',
+  'functionStatic': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/functionStatic.md',
+  'premium-misra-config': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/premium-misra-config.md',
+  'preprocessorErrorDirective': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/preprocessorErrorDirective.md',
+  'truncLongCast': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/truncLongCast.md',
+  'unknownMacro': 'https://github.com/cppcheck-opensource/cppcheck/blob/main/man/checkers/unknownMacro.md',
+};
+
+export { documentationLinkMap };


### PR DESCRIPTION
If we have documentation for checker ID we make the ID clickable with link to doc:

<img width="1054" height="195" alt="Screenshot 2026-05-19 at 11 46 35" src="https://github.com/user-attachments/assets/e1b553b7-f735-4cc7-a862-c987bdd2a43b" />
