### PR TITLE
fix / #75 run checks when changing file open in active text editor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,9 +208,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
         // Only analyze previewed files if user stays on them for 10 seconds
         if (tab && tab.isPreview) {
-            console.log('timer started');
             previewAnalysisTimer = setTimeout(() => {
-                console.log('analysis run');
                 handleDocument(editor.document);
             }, 10000);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,9 +174,25 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Run cppcheck when opening files in text editor
     vscode.window.onDidChangeActiveTextEditor(editor => {
-        if (editor) {
-            handleDocument(editor.document);
+        if (!editor) {
+            return;
         }
+        const tabs = vscode.window.tabGroups.all.flatMap(g => g.tabs);
+        const tab = tabs.find(t => {
+            return t.input instanceof vscode.TabInputText &&
+            t.input.uri.toString() === editor.document.uri.toString();
+        }
+        );
+        
+        if (!tab) {
+            return;
+        }
+        console.log('tab', tab, 'isPinned', tab.isPinned);
+        // Ignore preview tabs
+        if (!tab.isPinned) {
+            return;
+        }
+        handleDocument(editor.document);
     }, null, context.subscriptions);
 
     // Run cppcheck for all open files when the workspace is opened

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,6 +172,13 @@ export async function activate(context: vscode.ExtensionContext) {
     // Run cppcheck when a file is opened
     vscode.workspace.onDidOpenTextDocument(handleDocument, null, context.subscriptions);
 
+    // Run cppcheck when opening files in text editor
+    vscode.window.onDidChangeActiveTextEditor(editor => {
+        if (editor) {
+            handleDocument(editor.document);
+        }
+    }, null, context.subscriptions);
+
     // Run cppcheck for all open files when the workspace is opened
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
         vscode.workspace.textDocuments.forEach(handleDocument);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,7 +238,6 @@ export async function activate(context: vscode.ExtensionContext) {
     // Clean up diagnostics when a file is closed
     vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
         diagnosticCollection.delete(document.uri);
-        documentHashMemory[document.fileName] = '';
     }, null, context.subscriptions);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { looksLikePath, resolvePath, findWorkspaceRoot } from './util/path';
 let documentHashMemory : Record<string, string> = {};
 
 let previewAnalysisTimer: NodeJS.Timeout | undefined;
+let previewedDocument: vscode.TextDocument | undefined;
 let cppcheckProgressIndicator: vscode.StatusBarItem;
 let checksRunning = false;
 
@@ -193,28 +194,38 @@ export async function activate(context: vscode.ExtensionContext) {
     // Run cppcheck when a file is opened
     vscode.workspace.onDidOpenTextDocument(handleDocument, null, context.subscriptions);
 
-    // Run cppcheck when opening files in text editor
-    vscode.window.onDidChangeActiveTextEditor(editor => {
+    // Run cppcheck when changing files viewed in text editor
+    vscode.window.tabGroups.onDidChangeTabs(async e => {
         clearTimeout(previewAnalysisTimer);
-        if (!editor) {
-            return;
+        for (const tab of e.changed) {
+            if (tab.input instanceof vscode.TabInputText) {
+                const uri = tab.input.uri;
+                const document =
+                    vscode.workspace.textDocuments.find(
+                        doc => doc.uri.toString() === uri.toString()
+                    ) ?? await vscode.workspace.openTextDocument(uri);
+                // Only analyze previewed files if user stays on them for 10 seconds
+                if (tab && tab.isPreview) {
+                    previewAnalysisTimer = setTimeout(() => {
+                        handleDocument(document);
+                        previewedDocument = document;
+                    }, 10000);
+                } else {
+                    // If file is properly opened we run analysis right away
+                    handleDocument(document);
+                }
+            }
         }
-        const tabs = vscode.window.tabGroups.all.flatMap(g => g.tabs);
-        const tab = tabs.find(t => {
-            return t.input instanceof vscode.TabInputText &&
-            t.input.uri.toString() === editor.document.uri.toString();
-        }
-        );
-
-        // Only analyze previewed files if user stays on them for 10 seconds
-        if (tab && tab.isPreview) {
-            previewAnalysisTimer = setTimeout(() => {
-                handleDocument(editor.document);
-            }, 10000);
-        }
-
-        handleDocument(editor.document);
     }, null, context.subscriptions);
+
+    // Clear diagnostics of previewed files when no longer viewed
+    vscode.window.onDidChangeActiveTextEditor(() => {
+        if (previewedDocument) {
+            diagnosticCollection.delete(previewedDocument.uri);
+            documentHashMemory[previewedDocument.fileName] = '';
+            previewedDocument = undefined;
+        }
+    });
 
     // Run cppcheck for all open files when the workspace is opened
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
@@ -227,6 +238,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Clean up diagnostics when a file is closed
     vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
         diagnosticCollection.delete(document.uri);
+        documentHashMemory[document.fileName] = '';
     }, null, context.subscriptions);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { looksLikePath, resolvePath, findWorkspaceRoot } from './util/path';
 // To keep track of document changes we save hashed versions of their content to this record
 let documentHashMemory : Record<string, string> = {};
 
+let previewAnalysisTimer: NodeJS.Timeout | undefined;
 let cppcheckProgressIndicator: vscode.StatusBarItem;
 let checksRunning = false;
 
@@ -194,6 +195,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Run cppcheck when opening files in text editor
     vscode.window.onDidChangeActiveTextEditor(editor => {
+        clearTimeout(previewAnalysisTimer);
         if (!editor) {
             return;
         }
@@ -203,15 +205,16 @@ export async function activate(context: vscode.ExtensionContext) {
             t.input.uri.toString() === editor.document.uri.toString();
         }
         );
-        
-        if (!tab) {
-            return;
+
+        // Only analyze previewed files if user stays on them for 10 seconds
+        if (tab && tab.isPreview) {
+            console.log('timer started');
+            previewAnalysisTimer = setTimeout(() => {
+                console.log('analysis run');
+                handleDocument(editor.document);
+            }, 10000);
         }
-        console.log('tab', tab, 'isPinned', tab.isPinned);
-        // Ignore preview tabs
-        if (!tab.isPinned) {
-            return;
-        }
+
         handleDocument(editor.document);
     }, null, context.subscriptions);
 


### PR DESCRIPTION
This means that when you click around in the project file tree checks will run for files opened. Previously we only ran checks when files were opened through File -> Open