### PR TITLE
fix #80 / analysis not run if files closed and opened without changing content

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,6 +163,7 @@ export async function activate(context: vscode.ExtensionContext) {
         // If disabled, clear any existing diagnostics for this doc.
         if (!isEnabled) {
             diagnosticCollection.delete(document.uri);
+            documentHashMemory[document.fileName] = '';
             return;
         }
 
@@ -203,6 +204,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Clean up diagnostics when a file is closed
     vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
         diagnosticCollection.delete(document.uri);
+        documentHashMemory[document.fileName] = '';
     }, null, context.subscriptions);
 }
 


### PR DESCRIPTION
if a file is closed it's diagnosis is cleared, so this created a state where you might not see problems for a file