### PR TITLE
feature / #87 toggle severity with status bar item

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ let fileRelationMap: Record<string, Set<string>> = {};
 let previewAnalysisTimer: NodeJS.Timeout | undefined;
 let previewedDocument: vscode.TextDocument | undefined;
 let cppcheckProgressIndicator: vscode.StatusBarItem;
+let severityOption: vscode.StatusBarItem;
 let checksRunning = false;
 let cppcheckProjectFileUri: vscode.Uri | undefined;
 
@@ -83,9 +84,18 @@ function updateProgressIndicator(): void {
 	if (checksRunning) {
 		cppcheckProgressIndicator.text = `$(loading~spin) Cppcheck Running ..`;
 		cppcheckProgressIndicator.show();
+        // severityOption.hide();
 	} else {
 		cppcheckProgressIndicator.hide();
+        // severityOption.show();
 	}
+}
+
+function updateMinSeverityOption(): void {
+    const mode = vscode.workspace.getConfiguration('cppcheck-official').get<string>('minSeverity', 'info');
+    severityOption.text = `$(gear) Cppcheck severity: ${mode}`;
+    severityOption.tooltip = 'Select minimum level of warning severity for cppcheck analysis';
+    severityOption.show();
 }
 
 function getDocumentSha1(document: vscode.TextDocument): string {
@@ -191,9 +201,68 @@ export async function activate(context: vscode.ExtensionContext) {
         )
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            "cppcheck-official.selectMinSeverity",
+            async () => {
+                const current = vscode.workspace
+                    .getConfiguration("cppcheck-official")
+                    .get<string>("minSeverity", "info");
+
+                const selection = await vscode.window.showQuickPick(
+                    [
+                        {
+                            label: "Info",
+                            description: current === "info" ? "Cppcheck analysis minimum level: Info" : "",
+                            value: "info"
+                        },
+                        {
+                            label: "Warning",
+                            description: current === "warning" ? "Cppcheck analysis minimum level: Warning" : "",
+                            value: "warning"
+                        },
+                        {
+                            label: "Error",
+                            description: current === "error" ? "Cppcheck analysis minimum level: Error" : "",
+                            value: "error"
+                        }
+                    ],
+                    {
+                        title: "Select Mode"
+                    }
+                );
+                if (!selection) {
+                    return;
+                }
+
+                await vscode.workspace
+                    .getConfiguration("cppcheck-official")
+                    .update(
+                        "minSeverity",
+                        selection.value,
+                        vscode.ConfigurationTarget.Workspace
+                    );
+
+                updateMinSeverityOption();
+            }
+        )
+    );
+
     // ProgressIndicator status bar item to show when checks are running
 	cppcheckProgressIndicator = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
 	context.subscriptions.push(cppcheckProgressIndicator);
+
+    // Severity option status bar item
+    severityOption = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
+    severityOption.command = "cppcheck-official.selectMinSeverity";
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(event => {
+            if (event.affectsConfiguration("cppcheck-official.selectMinSeverity")) {
+                updateMinSeverityOption();
+            }
+        })
+    );
+    updateMinSeverityOption();
 
     function clearDiagnosticForDoc(doc: vscode.TextDocument): void {
         // Any file who was warnings generated from (and only from) the closed doc have their diagnostics cleared

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,10 +84,11 @@ function updateProgressIndicator(): void {
 	if (checksRunning) {
 		cppcheckProgressIndicator.text = `$(loading~spin) Cppcheck Running ..`;
 		cppcheckProgressIndicator.show();
-        // severityOption.hide();
+        // To avoid crowding status bar we alternate between progress indicator and severity option item
+        severityOption.hide();
 	} else {
 		cppcheckProgressIndicator.hide();
-        // severityOption.show();
+        severityOption.show();
 	}
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -263,6 +263,8 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         })
     );
+
+    // Call update function once at setup to set the UI text to the settings current value
     updateMinSeverityOption();
 
     function clearDiagnosticForDoc(doc: vscode.TextDocument): void {


### PR DESCRIPTION
I think the "correct" way to add UI elements for an extension is to add status bar items (see image 1). Clicking brings up the option window at the top (image 2). With this solution minSeverity is still a property in settings, but it can be changed from UI as well. 
<img width="894" height="428" alt="Screenshot 2026-07-24 at 22 12 50" src="https://github.com/user-attachments/assets/5df572e2-df43-496f-bb35-9df4f3eea20a" />
<img width="875" height="475" alt="Screenshot 2026-07-24 at 22 13 34" src="https://github.com/user-attachments/assets/fa1d6ced-b126-41fb-b193-6ca892169866" />

